### PR TITLE
Input bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.2.1 (2025-07-31)
+
+### Fix
+
+- **tracing**: Add `update_input` flag to control input tracking in traces
+- **tracing**: Fix bug where intermediate outputs overwrote original input in traces
+- **tracing**: Remove opinionated message filtering from trace decorator
+
 ## 0.2.0 (2025-07-23)
 
 ### Fix

--- a/cnoe_agent_utils/tracing/decorators.py
+++ b/cnoe_agent_utils/tracing/decorators.py
@@ -152,37 +152,3 @@ def trace_agent_stream(
                     
         return cast(AsyncStreamFunc, wrapper)
     return decorator
-
-
-def _is_generic_processing_message(content: str) -> bool:
-    """
-    Check if a message is a generic processing message that shouldn't be
-    captured as the final response in traces.
-    
-    Args:
-        content: Message content to check
-        
-    Returns:
-        bool: True if this is a generic processing message
-    """
-    generic_patterns = [
-        'Processing',
-        'Interacting with',
-        'Looking up', 
-        'Searching',
-        'Fetching',
-        '...',
-        'Please wait',
-        'Working on',
-        # Agent-specific generic messages
-        'Processing Slack operations',
-        'Interacting with Slack API',
-        'Processing ArgoCD operations', 
-        'Interacting with ArgoCD API',
-        'Processing Jira operations',
-        'Interacting with Jira API',
-        'Processing GitHub operations',
-        'Interacting with GitHub API',
-    ]
-    
-    return any(pattern in content for pattern in generic_patterns)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cnoe-agent-utils"
-version = "0.2.0"
+version = "0.2.1"
 description = "Core utilities for CNOE agents including LLM factory and tracing"
 authors = [
     {name = "CNOE Contributors"}


### PR DESCRIPTION
### Problem
The tracing decorator had a bug where the original user input in traces was being overwritten by intermediate agent outputs. This occurred because Langfuse's `update_trace()` method replaces all trace fields when called, rather than merging them.

### Solution
Added an `update_input` flag to the `@trace_agent_stream` decorator that controls whether the input field should be tracked in traces:

- **`update_input=False` (default)**: Input is never set in traces, providing privacy for sensitive queries
- **`update_input=True`**: Input is set initially and preserved throughout the trace lifecycle

### Usage
```python
# Default behavior - no input tracking
@trace_agent_stream("agent_name")
async def stream(self, query, context_id, trace_id=None):
    # Agent logic
    
# Preserve input in traces
@trace_agent_stream("agent_name", update_input=True)
async def stream(self, query, context_id, trace_id=None):
    # Agent logic
```

### Additional Changes
- Removed the opinionated `_is_generic_processing_message()` function that filtered out "processing" messages
- Now captures all content messages as the final output, letting agents decide what's meaningful
