### PR TITLE
fix: 'LLMFactory' object has no attribute 'provider'

### DIFF
--- a/cnoe_agent_utils/llm_factory.py
+++ b/cnoe_agent_utils/llm_factory.py
@@ -73,7 +73,7 @@ class LLMFactory:
         )
     if provider not in self.SUPPORTED_PROVIDERS:
       raise ValueError(
-        f"Unsupported provider: {self.provider}. Supported providers are: {self.SUPPORTED_PROVIDERS}"
+        f"Unsupported provider: {provider}. Supported providers are: {self.SUPPORTED_PROVIDERS}"
       )
     self.provider = provider.lower().replace("-", "_")
 


### PR DESCRIPTION
When a llm is not supported, the program crashes with `'LLMFactory' object has no attribute 'provider'`, instead of printing out the error message (with supported providers) as intended.