### PR TITLE
fix: don't send default temperature=0 to Claude Opus/Sonnet 5+ models

### DIFF
--- a/cnoe_agent_utils/llm_factory.py
+++ b/cnoe_agent_utils/llm_factory.py
@@ -55,68 +55,90 @@ _BEDROCK_CLIENT_ALIASES = {
     "chatbedrock": "legacy",
 }
 
-# Claude model families whose provider API rejects a non-default `temperature`
-# (and other sampling params) with a 400 error. Matched as a substring against
-# the (lowercased) model id so this also catches provider-prefixed forms like
-# "anthropic.claude-sonnet-5" (Bedrock) or "global.anthropic.claude-opus-5".
-_ANTHROPIC_DEFAULT_TEMPERATURE_ONLY_MODELS = (
+# Claude models that reject the sampling parameters (`temperature`, `top_p`,
+# `top_k`) with a 400: "`temperature` is deprecated for this model."
+#
+# Removal starts at Opus 4.7 / Sonnet 5 — Opus 4.6, Sonnet 4.6 and every earlier
+# Claude model still accept sampling parameters normally and must NOT be listed
+# here, or callers relying on temperature=0 silently lose deterministic output.
+#
+# Matched as a substring against the lowercased model id, so provider-prefixed
+# forms are covered too: "anthropic.claude-sonnet-5" (Bedrock),
+# "global.anthropic.claude-opus-5" (Bedrock cross-region inference profile).
+_ANTHROPIC_NO_SAMPLING_PARAM_MODELS = (
     "claude-opus-5",
     "claude-sonnet-5",
     "claude-fable-5",
     "claude-mythos-5",
-    "claude-opus-4-6",
     "claude-opus-4-7",
     "claude-opus-4-8",
-    "claude-sonnet-4-6",
 )
 
-# Anthropic's own default for `temperature` (see platform.claude.com/docs/en/api/messages).
-_ANTHROPIC_DEFAULT_TEMPERATURE = 1.0
+# Sampling params passed through **kwargs that these models also reject.
+_SAMPLING_PARAM_KWARGS = ("top_p", "top_k")
+
+# This library's historical implicit default, applied whenever a caller does not
+# pass one. `get_llm()` already resolves an unset temperature to this value, so a
+# builder receiving it cannot distinguish "unset" from "explicitly set to 0".
+_LIBRARY_DEFAULT_TEMPERATURE = 0.0
 
 
-def _model_requires_default_temperature(model_id: Optional[str]) -> bool:
-    """True if `model_id` is a Claude model that 400s on non-default sampling params.
-
-    These models only accept `temperature`/`top_p`/`top_k` at their provider
-    default (temperature=1.0) — any other value, including this library's own
-    implicit default of 0, is rejected with:
-        `temperature` is deprecated for this model.
-    """
+def _model_rejects_sampling_params(model_id: Optional[str]) -> bool:
+    """True if `model_id` is a Claude model that 400s on any sampling parameter."""
     if not model_id:
         return False
     lowered = model_id.lower()
-    return any(needle in lowered for needle in _ANTHROPIC_DEFAULT_TEMPERATURE_ONLY_MODELS)
+    return any(needle in lowered for needle in _ANTHROPIC_NO_SAMPLING_PARAM_MODELS)
 
 
-def _resolve_temperature_kwarg(
+def _sanitize_sampling_params(
     model_id: Optional[str],
     temperature: Optional[float],
+    kwargs: Dict[str, Any],
     provider_label: str,
-) -> Dict[str, float]:
-    """Build the `{"temperature": ...}` kwarg dict for a Claude request.
+) -> tuple[Dict[str, Any], Dict[str, Any]]:
+    """Split sampling parameters out of a Claude request.
 
-    Backward compatible: for every model outside `_ANTHROPIC_DEFAULT_TEMPERATURE_ONLY_MODELS`,
-    behavior is unchanged — `temperature` if explicitly given, else this
-    library's long-standing default of 0.
+    Returns ``(sampling_kwargs, remaining_kwargs)`` to merge into the client
+    constructor call.
 
-    For the restricted models, `temperature` is included only when it is
-    Anthropic's own default (1.0) or unset (in which case we pass 1.0
-    explicitly rather than this library's default of 0, which those models
-    reject). An explicit non-default value is dropped (not sent) with a
-    warning instead of causing a hard 400 at request time.
+    Backward compatible: for every model outside
+    `_ANTHROPIC_NO_SAMPLING_PARAM_MODELS`, behavior is unchanged — `temperature`
+    if given, else this library's long-standing default of 0, and `top_p`/`top_k`
+    passed straight through.
+
+    For the restricted models every sampling parameter is omitted entirely rather
+    than sent at some "safe" value. The docs are inconsistent about whether these
+    models accept the parameter at Anthropic's own default (1.0) or reject it at
+    any value, so omitting is the only behavior that is correct under both
+    readings — and omitting is what Anthropic's migration guide prescribes.
     """
-    if not _model_requires_default_temperature(model_id):
-        return {"temperature": temperature if temperature is not None else 0}
+    if not _model_rejects_sampling_params(model_id):
+        return {"temperature": temperature if temperature is not None else 0}, kwargs
 
-    if temperature is None or temperature == _ANTHROPIC_DEFAULT_TEMPERATURE:
-        return {"temperature": _ANTHROPIC_DEFAULT_TEMPERATURE}
+    remaining = {k: v for k, v in kwargs.items() if k not in _SAMPLING_PARAM_KWARGS}
 
-    logging.warning(
-        "[LLM] model=%s (%s) only accepts the default temperature (%s); "
-        "dropping explicit temperature=%s instead of sending a value the API will reject.",
-        model_id, provider_label, _ANTHROPIC_DEFAULT_TEMPERATURE, temperature,
-    )
-    return {}
+    # Only warn about values the caller plausibly chose. An unset temperature has
+    # already been resolved to _LIBRARY_DEFAULT_TEMPERATURE upstream, so treating
+    # it as noteworthy would warn on every single default construction.
+    dropped = [
+        f"{k}={kwargs[k]}" for k in _SAMPLING_PARAM_KWARGS if k in kwargs
+    ]
+    if temperature is not None and temperature != _LIBRARY_DEFAULT_TEMPERATURE:
+        dropped.insert(0, f"temperature={temperature}")
+
+    if dropped:
+        logging.warning(
+            "[LLM] model=%s (%s) does not accept sampling parameters; dropping %s "
+            "instead of sending values the API rejects with a 400.",
+            model_id, provider_label, ", ".join(dropped),
+        )
+    else:
+        logging.debug(
+            "[LLM] model=%s (%s) does not accept sampling parameters; omitting temperature.",
+            model_id, provider_label,
+        )
+    return {}, remaining
 
 
 def _as_bool(v: Optional[str], default: bool=False) -> bool:
@@ -517,9 +539,12 @@ class LLMFactory:
         logging.info(f"[LLM] Bedrock botocore config: {botocore_config_kwargs}")
 
     # Build common args for both ChatBedrock and ChatBedrockConverse
+    sampling_args, kwargs = _sanitize_sampling_params(
+      model_id, temperature, kwargs, "AWS Bedrock"
+    )
     common_args = {
       "model_id": model_id,
-      **_resolve_temperature_kwarg(model_id, temperature, "AWS Bedrock"),
+      **sampling_args,
       **kwargs,
     }
 
@@ -665,11 +690,15 @@ class LLMFactory:
       model_kwargs["thinking_budget"] = thinking_budget
       logging.info(f"[LLM] Extended thinking configured with thinking_budget={thinking_budget}")
 
+    sampling_args, kwargs = _sanitize_sampling_params(
+      model_name, temperature, kwargs, "Anthropic"
+    )
+
     return ChatAnthropic(
       model_name=model_name,
       anthropic_api_key=api_key,
       model_kwargs=model_kwargs,
-      **_resolve_temperature_kwarg(model_name, temperature, "Anthropic"),
+      **sampling_args,
       **kwargs,
     )
 
@@ -994,7 +1023,7 @@ class LLMFactory:
       "project": project_id,
       "location": location,
       "credentials": credentials,
-      **_resolve_temperature_kwarg(model_name, temperature, "Google Vertex AI"),
+      "temperature": temperature if temperature is not None else 0,
       "max_retries": 6,
       "stop": None,
       "model_kwargs": model_kwargs,

--- a/cnoe_agent_utils/llm_factory.py
+++ b/cnoe_agent_utils/llm_factory.py
@@ -55,6 +55,70 @@ _BEDROCK_CLIENT_ALIASES = {
     "chatbedrock": "legacy",
 }
 
+# Claude model families whose provider API rejects a non-default `temperature`
+# (and other sampling params) with a 400 error. Matched as a substring against
+# the (lowercased) model id so this also catches provider-prefixed forms like
+# "anthropic.claude-sonnet-5" (Bedrock) or "global.anthropic.claude-opus-5".
+_ANTHROPIC_DEFAULT_TEMPERATURE_ONLY_MODELS = (
+    "claude-opus-5",
+    "claude-sonnet-5",
+    "claude-fable-5",
+    "claude-mythos-5",
+    "claude-opus-4-6",
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+    "claude-sonnet-4-6",
+)
+
+# Anthropic's own default for `temperature` (see platform.claude.com/docs/en/api/messages).
+_ANTHROPIC_DEFAULT_TEMPERATURE = 1.0
+
+
+def _model_requires_default_temperature(model_id: Optional[str]) -> bool:
+    """True if `model_id` is a Claude model that 400s on non-default sampling params.
+
+    These models only accept `temperature`/`top_p`/`top_k` at their provider
+    default (temperature=1.0) — any other value, including this library's own
+    implicit default of 0, is rejected with:
+        `temperature` is deprecated for this model.
+    """
+    if not model_id:
+        return False
+    lowered = model_id.lower()
+    return any(needle in lowered for needle in _ANTHROPIC_DEFAULT_TEMPERATURE_ONLY_MODELS)
+
+
+def _resolve_temperature_kwarg(
+    model_id: Optional[str],
+    temperature: Optional[float],
+    provider_label: str,
+) -> Dict[str, float]:
+    """Build the `{"temperature": ...}` kwarg dict for a Claude request.
+
+    Backward compatible: for every model outside `_ANTHROPIC_DEFAULT_TEMPERATURE_ONLY_MODELS`,
+    behavior is unchanged — `temperature` if explicitly given, else this
+    library's long-standing default of 0.
+
+    For the restricted models, `temperature` is included only when it is
+    Anthropic's own default (1.0) or unset (in which case we pass 1.0
+    explicitly rather than this library's default of 0, which those models
+    reject). An explicit non-default value is dropped (not sent) with a
+    warning instead of causing a hard 400 at request time.
+    """
+    if not _model_requires_default_temperature(model_id):
+        return {"temperature": temperature if temperature is not None else 0}
+
+    if temperature is None or temperature == _ANTHROPIC_DEFAULT_TEMPERATURE:
+        return {"temperature": _ANTHROPIC_DEFAULT_TEMPERATURE}
+
+    logging.warning(
+        "[LLM] model=%s (%s) only accepts the default temperature (%s); "
+        "dropping explicit temperature=%s instead of sending a value the API will reject.",
+        model_id, provider_label, _ANTHROPIC_DEFAULT_TEMPERATURE, temperature,
+    )
+    return {}
+
+
 def _as_bool(v: Optional[str], default: bool=False) -> bool:
     if v is None:
         return default
@@ -455,7 +519,7 @@ class LLMFactory:
     # Build common args for both ChatBedrock and ChatBedrockConverse
     common_args = {
       "model_id": model_id,
-      "temperature": temperature if temperature is not None else 0,
+      **_resolve_temperature_kwarg(model_id, temperature, "AWS Bedrock"),
       **kwargs,
     }
 
@@ -604,8 +668,8 @@ class LLMFactory:
     return ChatAnthropic(
       model_name=model_name,
       anthropic_api_key=api_key,
-      temperature=temperature if temperature is not None else 0,
       model_kwargs=model_kwargs,
+      **_resolve_temperature_kwarg(model_name, temperature, "Anthropic"),
       **kwargs,
     )
 
@@ -930,7 +994,7 @@ class LLMFactory:
       "project": project_id,
       "location": location,
       "credentials": credentials,
-      "temperature": temperature if temperature is not None else 0,
+      **_resolve_temperature_kwarg(model_name, temperature, "Google Vertex AI"),
       "max_retries": 6,
       "stop": None,
       "model_kwargs": model_kwargs,

--- a/tests/test_llm_factory.py
+++ b/tests/test_llm_factory.py
@@ -472,8 +472,9 @@ class TestLLMFactoryTemperature:
 class TestClaudeDefaultOnlyTemperature:
     """Regression tests for the Claude 5 / 4.6+ 'temperature is deprecated' 400.
 
-    These models reject any non-default `temperature` (Anthropic's own default
-    is 1.0, not this library's implicit default of 0) — see
+    Sampling parameters are removed starting at Opus 4.7 / Sonnet 5, so they must
+    be omitted from the request entirely. Opus 4.6, Sonnet 4.6 and earlier still
+    accept them and must keep this library's historical default of 0. See
     https://platform.claude.com/docs/en/api/errors.md and
     https://platform.claude.com/docs/en/about-claude/models/migration-guide.md.
     """
@@ -483,17 +484,15 @@ class TestClaudeDefaultOnlyTemperature:
         "claude-sonnet-5",
         "claude-fable-5",
         "claude-mythos-5",
-        "claude-opus-4-6",
         "claude-opus-4-7",
         "claude-opus-4-8",
-        "claude-sonnet-4-6",
         "anthropic.claude-sonnet-5",          # Bedrock-prefixed
         "global.anthropic.claude-sonnet-5",   # Bedrock inference-profile-prefixed
         "CLAUDE-OPUS-5",                      # case-insensitive
     ])
     def test_restricted_models_detected(self, model_id):
-        from cnoe_agent_utils.llm_factory import _model_requires_default_temperature
-        assert _model_requires_default_temperature(model_id) is True
+        from cnoe_agent_utils.llm_factory import _model_rejects_sampling_params
+        assert _model_rejects_sampling_params(model_id) is True
 
     @pytest.mark.parametrize("model_id", [
         None,
@@ -501,25 +500,29 @@ class TestClaudeDefaultOnlyTemperature:
         "claude-3-sonnet-20240229-v1",
         "claude-sonnet-4-5",
         "claude-opus-4-5",
+        # Sampling params are still ALLOWED on the 4.6 generation — regression
+        # guard so these never get pulled back into the restricted list.
+        "claude-opus-4-6",
+        "claude-sonnet-4-6",
         "gpt-5",
         "anthropic.claude-3-haiku-20240307-v1:0",
     ])
     def test_unrestricted_models_not_detected(self, model_id):
-        from cnoe_agent_utils.llm_factory import _model_requires_default_temperature
-        assert _model_requires_default_temperature(model_id) is False
+        from cnoe_agent_utils.llm_factory import _model_rejects_sampling_params
+        assert _model_rejects_sampling_params(model_id) is False
 
-    def test_bedrock_builder_omits_zero_default_for_restricted_model(self):
-        """The library's implicit default of 0 must not be sent to Claude 5 —
-        it should be replaced with Anthropic's actual default (1.0)."""
+    def test_bedrock_builder_omits_temperature_for_restricted_model(self):
+        """The library's implicit default of 0 must not reach Claude 5, and no
+        substitute value may be sent either — the key must be absent."""
         factory = LLMFactory("aws-bedrock")
         with patch.dict(os.environ, {
             "AWS_BEDROCK_MODEL_ID": "anthropic.claude-sonnet-5",
             "AWS_REGION": "us-east-1",
         }):
             with patch("langchain_aws.ChatAnthropicBedrock") as mock_chat:
-                factory._build_aws_bedrock_llm(None, None)
+                factory._build_aws_bedrock_llm(None, 0.0)
                 _, kwargs = mock_chat.call_args
-                assert kwargs.get("temperature") == 1.0
+                assert "temperature" not in kwargs
 
     def test_bedrock_builder_unaffected_for_older_model(self):
         """Backward compatibility: models outside the restricted list keep the
@@ -534,39 +537,103 @@ class TestClaudeDefaultOnlyTemperature:
                 _, kwargs = mock_chat.call_args
                 assert kwargs.get("temperature") == 0
 
-    def test_bedrock_builder_drops_explicit_non_default_for_restricted_model(self):
-        """An explicit non-default temperature on a restricted model is dropped
-        (not sent) rather than forwarded to a request that would 400."""
+    def test_bedrock_builder_unaffected_for_4_6_model(self):
+        """Opus/Sonnet 4.6 accept sampling params — an explicit 0.3 must survive."""
         factory = LLMFactory("aws-bedrock")
         with patch.dict(os.environ, {
-            "AWS_BEDROCK_MODEL_ID": "anthropic.claude-opus-5",
+            "AWS_BEDROCK_MODEL_ID": "anthropic.claude-sonnet-4-6",
             "AWS_REGION": "us-east-1",
         }):
             with patch("langchain_aws.ChatAnthropicBedrock") as mock_chat:
                 factory._build_aws_bedrock_llm(None, 0.3)
                 _, kwargs = mock_chat.call_args
-                assert "temperature" not in kwargs
+                assert kwargs.get("temperature") == 0.3
 
-    def test_bedrock_builder_keeps_explicit_default_for_restricted_model(self):
-        """An explicit temperature matching Anthropic's default (1.0) is kept."""
+    @pytest.mark.parametrize("temperature", [0.0, 0.3, 1.0, 2.0])
+    def test_bedrock_builder_omits_every_temperature_for_restricted_model(self, temperature):
+        """No temperature value — including Anthropic's default of 1.0 — is sent."""
         factory = LLMFactory("aws-bedrock")
         with patch.dict(os.environ, {
             "AWS_BEDROCK_MODEL_ID": "anthropic.claude-opus-5",
             "AWS_REGION": "us-east-1",
         }):
             with patch("langchain_aws.ChatAnthropicBedrock") as mock_chat:
-                factory._build_aws_bedrock_llm(None, 1.0)
+                factory._build_aws_bedrock_llm(None, temperature)
                 _, kwargs = mock_chat.call_args
-                assert kwargs.get("temperature") == 1.0
+                assert "temperature" not in kwargs
 
-    def test_anthropic_builder_omits_zero_default_for_restricted_model(self):
+    def test_bedrock_builder_strips_top_p_and_top_k_for_restricted_model(self):
+        """top_p/top_k are rejected by the same models and must also be stripped."""
+        factory = LLMFactory("aws-bedrock")
+        with patch.dict(os.environ, {
+            "AWS_BEDROCK_MODEL_ID": "anthropic.claude-opus-5",
+            "AWS_REGION": "us-east-1",
+        }):
+            with patch("langchain_aws.ChatAnthropicBedrock") as mock_chat:
+                factory._build_aws_bedrock_llm(None, 0.0, top_p=0.9, top_k=40)
+                _, kwargs = mock_chat.call_args
+                assert "top_p" not in kwargs
+                assert "top_k" not in kwargs
+
+    def test_bedrock_builder_keeps_top_p_for_older_model(self):
+        factory = LLMFactory("aws-bedrock")
+        with patch.dict(os.environ, {
+            "AWS_BEDROCK_MODEL_ID": "anthropic.claude-3-sonnet-20240229-v1:0",
+            "AWS_REGION": "us-east-1",
+        }):
+            with patch("langchain_aws.ChatAnthropicBedrock") as mock_chat:
+                factory._build_aws_bedrock_llm(None, None, top_p=0.9)
+                _, kwargs = mock_chat.call_args
+                assert kwargs.get("top_p") == 0.9
+
+    def test_get_llm_public_path_omits_temperature_for_restricted_model(self):
+        """Covers the real code path: get_llm() resolves an unset temperature to
+        0.0 before the builder sees it, so the builder must handle that value."""
+        factory = LLMFactory("aws-bedrock")
+        with patch.dict(os.environ, {
+            "AWS_BEDROCK_MODEL_ID": "anthropic.claude-opus-5",
+            "AWS_REGION": "us-east-1",
+        }, clear=False):
+            with patch("langchain_aws.ChatAnthropicBedrock") as mock_chat:
+                factory.get_llm()
+                _, kwargs = mock_chat.call_args
+                assert "temperature" not in kwargs
+
+    def test_no_warning_when_caller_set_no_temperature(self, caplog):
+        """A default construction must not log a warning about 'dropping' a value
+        the caller never set."""
+        factory = LLMFactory("aws-bedrock")
+        with patch.dict(os.environ, {
+            "AWS_BEDROCK_MODEL_ID": "anthropic.claude-opus-5",
+            "AWS_REGION": "us-east-1",
+        }):
+            with patch("langchain_aws.ChatAnthropicBedrock"):
+                with caplog.at_level("WARNING"):
+                    factory.get_llm()
+        assert "does not accept sampling parameters" not in caplog.text
+
+    def test_warning_when_caller_set_explicit_temperature(self, caplog):
+        factory = LLMFactory("aws-bedrock")
+        with patch.dict(os.environ, {
+            "AWS_BEDROCK_MODEL_ID": "anthropic.claude-opus-5",
+            "AWS_REGION": "us-east-1",
+        }):
+            with patch("langchain_aws.ChatAnthropicBedrock"):
+                with caplog.at_level("WARNING"):
+                    factory._build_aws_bedrock_llm(None, 0.7)
+        assert "does not accept sampling parameters" in caplog.text
+        assert "temperature=0.7" in caplog.text
+
+    def test_anthropic_builder_omits_temperature_for_restricted_model(self):
         factory = LLMFactory("anthropic-claude")
         with patch.dict(os.environ, {
             "ANTHROPIC_API_KEY": "test-key",
             "ANTHROPIC_MODEL_NAME": "claude-sonnet-5",
         }):
-            llm = factory._build_anthropic_claude_llm(None, None)
-            assert llm.temperature == 1.0
+            with patch("langchain_anthropic.ChatAnthropic") as mock_chat:
+                factory._build_anthropic_claude_llm(None, 0.0)
+                _, kwargs = mock_chat.call_args
+                assert "temperature" not in kwargs
 
     def test_anthropic_builder_unaffected_for_older_model(self):
         factory = LLMFactory("anthropic-claude")
@@ -576,6 +643,15 @@ class TestClaudeDefaultOnlyTemperature:
         }):
             llm = factory._build_anthropic_claude_llm(None, None)
             assert llm.temperature == 0
+
+    def test_vertexai_builder_is_not_subject_to_anthropic_rule(self):
+        """_build_gcp_vertexai_llm constructs ChatVertexAI (Gemini), not
+        ChatAnthropicVertex, so the Anthropic sampling rule must not apply."""
+        import inspect
+        from cnoe_agent_utils.llm_factory import LLMFactory as _F
+        src = inspect.getsource(_F._build_gcp_vertexai_llm)
+        assert "_sanitize_sampling_params" not in src
+        assert "temperature" in src
 
 
 if __name__ == "__main__":

--- a/tests/test_llm_factory.py
+++ b/tests/test_llm_factory.py
@@ -469,5 +469,114 @@ class TestLLMFactoryTemperature:
                 mock_builder.assert_called_once_with(None, 0.0)  # Falls back to 0.0
 
 
+class TestClaudeDefaultOnlyTemperature:
+    """Regression tests for the Claude 5 / 4.6+ 'temperature is deprecated' 400.
+
+    These models reject any non-default `temperature` (Anthropic's own default
+    is 1.0, not this library's implicit default of 0) — see
+    https://platform.claude.com/docs/en/api/errors.md and
+    https://platform.claude.com/docs/en/about-claude/models/migration-guide.md.
+    """
+
+    @pytest.mark.parametrize("model_id", [
+        "claude-opus-5",
+        "claude-sonnet-5",
+        "claude-fable-5",
+        "claude-mythos-5",
+        "claude-opus-4-6",
+        "claude-opus-4-7",
+        "claude-opus-4-8",
+        "claude-sonnet-4-6",
+        "anthropic.claude-sonnet-5",          # Bedrock-prefixed
+        "global.anthropic.claude-sonnet-5",   # Bedrock inference-profile-prefixed
+        "CLAUDE-OPUS-5",                      # case-insensitive
+    ])
+    def test_restricted_models_detected(self, model_id):
+        from cnoe_agent_utils.llm_factory import _model_requires_default_temperature
+        assert _model_requires_default_temperature(model_id) is True
+
+    @pytest.mark.parametrize("model_id", [
+        None,
+        "",
+        "claude-3-sonnet-20240229-v1",
+        "claude-sonnet-4-5",
+        "claude-opus-4-5",
+        "gpt-5",
+        "anthropic.claude-3-haiku-20240307-v1:0",
+    ])
+    def test_unrestricted_models_not_detected(self, model_id):
+        from cnoe_agent_utils.llm_factory import _model_requires_default_temperature
+        assert _model_requires_default_temperature(model_id) is False
+
+    def test_bedrock_builder_omits_zero_default_for_restricted_model(self):
+        """The library's implicit default of 0 must not be sent to Claude 5 —
+        it should be replaced with Anthropic's actual default (1.0)."""
+        factory = LLMFactory("aws-bedrock")
+        with patch.dict(os.environ, {
+            "AWS_BEDROCK_MODEL_ID": "anthropic.claude-sonnet-5",
+            "AWS_REGION": "us-east-1",
+        }):
+            with patch("langchain_aws.ChatAnthropicBedrock") as mock_chat:
+                factory._build_aws_bedrock_llm(None, None)
+                _, kwargs = mock_chat.call_args
+                assert kwargs.get("temperature") == 1.0
+
+    def test_bedrock_builder_unaffected_for_older_model(self):
+        """Backward compatibility: models outside the restricted list keep the
+        library's original default of 0."""
+        factory = LLMFactory("aws-bedrock")
+        with patch.dict(os.environ, {
+            "AWS_BEDROCK_MODEL_ID": "anthropic.claude-3-sonnet-20240229-v1:0",
+            "AWS_REGION": "us-east-1",
+        }):
+            with patch("langchain_aws.ChatAnthropicBedrock") as mock_chat:
+                factory._build_aws_bedrock_llm(None, None)
+                _, kwargs = mock_chat.call_args
+                assert kwargs.get("temperature") == 0
+
+    def test_bedrock_builder_drops_explicit_non_default_for_restricted_model(self):
+        """An explicit non-default temperature on a restricted model is dropped
+        (not sent) rather than forwarded to a request that would 400."""
+        factory = LLMFactory("aws-bedrock")
+        with patch.dict(os.environ, {
+            "AWS_BEDROCK_MODEL_ID": "anthropic.claude-opus-5",
+            "AWS_REGION": "us-east-1",
+        }):
+            with patch("langchain_aws.ChatAnthropicBedrock") as mock_chat:
+                factory._build_aws_bedrock_llm(None, 0.3)
+                _, kwargs = mock_chat.call_args
+                assert "temperature" not in kwargs
+
+    def test_bedrock_builder_keeps_explicit_default_for_restricted_model(self):
+        """An explicit temperature matching Anthropic's default (1.0) is kept."""
+        factory = LLMFactory("aws-bedrock")
+        with patch.dict(os.environ, {
+            "AWS_BEDROCK_MODEL_ID": "anthropic.claude-opus-5",
+            "AWS_REGION": "us-east-1",
+        }):
+            with patch("langchain_aws.ChatAnthropicBedrock") as mock_chat:
+                factory._build_aws_bedrock_llm(None, 1.0)
+                _, kwargs = mock_chat.call_args
+                assert kwargs.get("temperature") == 1.0
+
+    def test_anthropic_builder_omits_zero_default_for_restricted_model(self):
+        factory = LLMFactory("anthropic-claude")
+        with patch.dict(os.environ, {
+            "ANTHROPIC_API_KEY": "test-key",
+            "ANTHROPIC_MODEL_NAME": "claude-sonnet-5",
+        }):
+            llm = factory._build_anthropic_claude_llm(None, None)
+            assert llm.temperature == 1.0
+
+    def test_anthropic_builder_unaffected_for_older_model(self):
+        factory = LLMFactory("anthropic-claude")
+        with patch.dict(os.environ, {
+            "ANTHROPIC_API_KEY": "test-key",
+            "ANTHROPIC_MODEL_NAME": "claude-3-sonnet-20240229-v1",
+        }):
+            llm = factory._build_anthropic_claude_llm(None, None)
+            assert llm.temperature == 0
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Claude models from Opus 4.7 / Sonnet 5 onward reject the sampling parameters (`temperature`, `top_p`, `top_k`) with a 400:

```
anthropic.BadRequestError: Error code: 400 - {'message': '`temperature` is deprecated for this model.'}
```

This library implicitly defaults `temperature` to `0` whenever a caller doesn't pass one (`_get_default_temperature()`), so **every** request to these models — via AWS Bedrock or the Anthropic API — failed, even with no temperature configured anywhere. Hit in production on `global.anthropic.claude-sonnet-5`.

## Changes

- `_model_rejects_sampling_params(model_id)` — matches the affected families as a substring, so provider-prefixed ids are covered too (`anthropic.claude-sonnet-5`, `global.anthropic.claude-opus-5`).
- `_sanitize_sampling_params(...)` — for those models, **omits** `temperature`/`top_p`/`top_k` from the request entirely rather than substituting a "safe" value. The docs are inconsistent about whether the parameter is rejected at *any* value or only at a non-default one, and omitting is correct under both readings.
- Applied to `_build_aws_bedrock_llm` and `_build_anthropic_claude_llm` only. `_build_gcp_vertexai_llm` constructs `ChatVertexAI` (Gemini), not `ChatAnthropicVertex`, so it is deliberately untouched.

Values the caller actually chose are dropped with a `logging.warning`; an unset temperature (already resolved to the library default upstream) is logged at `debug` so normal construction stays quiet.

## Scope / backward compatibility

Only the models listed in `_ANTHROPIC_NO_SAMPLING_PARAM_MODELS` change behavior: Opus 5, Sonnet 5, Fable 5, Mythos 5, Opus 4.7, Opus 4.8.

**Opus 4.6, Sonnet 4.6 and every earlier Claude model still accept sampling parameters and are intentionally excluded** — including them would silently replace `temperature=0` with non-deterministic sampling for existing callers. There's a regression test guarding this. Non-Anthropic providers (OpenAI, Azure, Groq, Gemini, Vertex) are untouched.

## Test plan

- [x] 193 pre-existing tests still pass unchanged
- [x] +9 net new tests (`TestClaudeDefaultOnlyTemperature`), 202 total, covering:
  - model detection incl. Bedrock/inference-profile prefixes and case-insensitivity
  - 4.6-generation models explicitly asserted as *not* restricted
  - no `temperature` key sent for restricted models at any value (0.0 / 0.3 / 1.0 / 2.0)
  - `top_p`/`top_k` stripped for restricted models, preserved for older ones
  - the public `get_llm()` path, not just direct builder calls
  - warning fires only for caller-chosen values, not on default construction
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code), Claude Sonnet 5, with a self-review with Claude Opus 5.